### PR TITLE
Fix skipped tests

### DIFF
--- a/packages/jest-prisma/src/environment.ts
+++ b/packages/jest-prisma/src/environment.ts
@@ -47,7 +47,7 @@ export default class PrismaEnvironment extends NodeEnvironment {
   handleTestEvent(event: Circus.Event) {
     if (event.name === "test_start") {
       return this.beginTransaction();
-    } else if (event.name === "test_done") {
+    } else if (event.name === "test_done" || event.name === "test_skip") {
       return this.endTransaction();
     } else if (event.name === "test_fn_start") {
       logBuffer = [];


### PR DESCRIPTION
For a skipped test, jest still fires the `test_start` event (which triggers a new transaction) but instead of the `test_done` event, it fires `test_skip`. We need to call `endTransaction` for both events in order to properly close all transactions.