### PR TITLE
feat: add environment option `databaseUrl` for changing database url

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,15 @@ export interface JestPrismaEnvironmentOptions {
    *
    */
   readonly verboseQuery?: boolean;
+
+  /**
+   *
+   * Override the database connection URL.
+   *
+   * Useful if you have a separate database for testing.
+   *
+   */
+  readonly databaseUrl?: string;
 }
 ```
 

--- a/packages/jest-prisma-core/src/delegate.ts
+++ b/packages/jest-prisma-core/src/delegate.ts
@@ -26,15 +26,23 @@ export class PrismaEnvironmentDelegate implements PartialEnvironment {
   }
 
   constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
+    this.options = config.projectConfig.testEnvironmentOptions as JestPrismaEnvironmentOptions;
+
     const originalClient = new PrismaClient({
       log: [{ level: "query", emit: "event" }],
+      ...(this.options.databaseUrl && {
+        datasources: {
+          db: {
+            url: this.options.databaseUrl,
+          },
+        },
+      }),
     });
     originalClient.$on("query", event => {
       this.logBuffer?.push(event);
     });
     this.originalClient = originalClient;
 
-    this.options = config.projectConfig.testEnvironmentOptions as JestPrismaEnvironmentOptions;
     this.testPath = context.testPath.replace(config.globalConfig.rootDir, "").slice(1);
   }
 

--- a/packages/jest-prisma-core/src/types.ts
+++ b/packages/jest-prisma-core/src/types.ts
@@ -35,4 +35,13 @@ export interface JestPrismaEnvironmentOptions {
    *
    */
   readonly maxWait?: number;
+
+  /**
+   *
+   * Override the database connection URL.
+   *
+   * Default is the url set in the `DATABASE_URL` environment variable.
+   *
+   */
+  readonly databaseUrl?: string;
 }

--- a/packages/jest-prisma-node/src/types.ts
+++ b/packages/jest-prisma-node/src/types.ts
@@ -24,4 +24,13 @@ export interface JestPrismaEnvironmentOptions {
    *
    */
   readonly verboseQuery?: boolean;
+
+  /**
+   *
+   * Override the database connection URL.
+   *
+   * Default is the url set in the `DATABASE_URL` environment variable.
+   *
+   */
+  readonly databaseUrl?: string;
 }

--- a/packages/jest-prisma/src/types.ts
+++ b/packages/jest-prisma/src/types.ts
@@ -24,4 +24,13 @@ export interface JestPrismaEnvironmentOptions {
    *
    */
   readonly verboseQuery?: boolean;
+
+  /**
+   *
+   * Override the database connection URL.
+   *
+   * Default is the url set in the `DATABASE_URL` environment variable.
+   *
+   */
+  readonly databaseUrl?: string;
 }


### PR DESCRIPTION
Make it possible to change the database connection point by using the `datasources` option of prisma clinet.  
https://www.prisma.io/docs/reference/api-reference/prisma-client-reference#datasources

This is useful when users separate the database for development from that for testing.
