### PR TITLE
Custom prisma client output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,28 @@ Caveat: This work around might me affect your test cases using Jest fake timer f
 
 See also https://github.com/Quramy/jest-prisma/issues/56.
 
+### Custom prisma client output
+
+You can change the PrismaClient class used in `global.jestPrisma` by changing the `prismaPath` option and adding a `moduleNameMapper` to your jest config` file.
+
+```js
+// jest.config.js
+const prismaPath = require.resolve(".prisma/client");
+
+module.exports = {
+  moduleNameMapper: {
+    // Tests files are run within out environment, so we need to
+    // also map the path to the correct prisma client
+    "^.prisma/client/index$": prismaPath,
+  },
+  testEnvironmentOptions: {
+    prismaPath,
+  },
+};
+```
+
+This will allow you to use your own PrismaClient class.
+
 ## References
 
 ### `global.jestPrisma`
@@ -360,6 +382,14 @@ export interface JestPrismaEnvironmentOptions {
    *
    */
   readonly databaseUrl?: string;
+
+  /**
+   *
+   * Prisma client path. Useful for monorepos or when using a custom path for the generated prisma client.
+   *
+   * @default @prisma/client
+   */
+  readonly prismaPath?: string;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -300,28 +300,6 @@ Caveat: This work around might me affect your test cases using Jest fake timer f
 
 See also https://github.com/Quramy/jest-prisma/issues/56.
 
-### Working with a custom prisma output
-
-You can change the PrismaClient class used in `global.jestPrisma` by changing the `prismaPath` option and adding a `moduleNameMapper` to your jest config` file.
-
-```js
-// jest.config.js
-const prismaPath = require.resolve("my-prisma-folder");
-
-module.exports = {
-  moduleNameMapper: {
-    // Tests files are run within out environment, so we need to
-    // also map the path to the correct prisma client
-    "^.prisma/client/index$": prismaPath,
-  },
-  testEnvironmentOptions: {
-    prismaPath,
-  },
-};
-```
-
-This will allow you to use your own PrismaClient class.
-
 ## References
 
 ### `global.jestPrisma`

--- a/README.md
+++ b/README.md
@@ -300,13 +300,13 @@ Caveat: This work around might me affect your test cases using Jest fake timer f
 
 See also https://github.com/Quramy/jest-prisma/issues/56.
 
-### Custom prisma client output
+### Working with a custom prisma output
 
 You can change the PrismaClient class used in `global.jestPrisma` by changing the `prismaPath` option and adding a `moduleNameMapper` to your jest config` file.
 
 ```js
 // jest.config.js
-const prismaPath = require.resolve(".prisma/client");
+const prismaPath = require.resolve("my-prisma-folder");
 
 module.exports = {
   moduleNameMapper: {
@@ -389,7 +389,7 @@ export interface JestPrismaEnvironmentOptions {
    *
    * @default @prisma/client
    */
-  readonly prismaPath?: string;
+  readonly prismaOutput?: string;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ export interface JestPrismaEnvironmentOptions {
    *
    * @default @prisma/client
    */
-  readonly prismaOutput?: string;
+  readonly prismaPath?: string;
 }
 ```
 

--- a/packages/jest-prisma-core/src/delegate.ts
+++ b/packages/jest-prisma-core/src/delegate.ts
@@ -5,7 +5,7 @@ import chalk from "chalk";
 
 import type { JestEnvironment } from "@jest/environment";
 
-import { PrismaClient, Prisma } from "@prisma/client";
+import type { PrismaClient, Prisma } from "@prisma/client";
 
 import type { JestPrisma, JestPrismaEnvironmentOptions } from "./types.js";
 
@@ -29,7 +29,9 @@ export class PrismaEnvironmentDelegate implements PartialEnvironment {
   constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
     this.options = config.projectConfig.testEnvironmentOptions as JestPrismaEnvironmentOptions;
 
-    const originalClient = new PrismaClient({
+    const Client = require(this.options.prismaPath || "@prisma/client").PrismaClient as PrismaClient;
+
+    const originalClient = new Client({
       log: [{ level: "query", emit: "event" }],
       ...(this.options.databaseUrl && {
         datasources: {

--- a/packages/jest-prisma-core/src/delegate.ts
+++ b/packages/jest-prisma-core/src/delegate.ts
@@ -1,11 +1,11 @@
+import type { EnvironmentContext, JestEnvironmentConfig } from "@jest/environment";
 import type { Circus } from "@jest/types";
-import type { JestEnvironmentConfig, EnvironmentContext } from "@jest/environment";
 
 import chalk from "chalk";
 
 import type { JestEnvironment } from "@jest/environment";
 
-import type { PrismaClient, Prisma } from "@prisma/client";
+import type { Prisma, PrismaClient } from "@prisma/client";
 
 import type { JestPrisma, JestPrismaEnvironmentOptions } from "./types.js";
 
@@ -29,9 +29,9 @@ export class PrismaEnvironmentDelegate implements PartialEnvironment {
   constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
     this.options = config.projectConfig.testEnvironmentOptions as JestPrismaEnvironmentOptions;
 
-    const Client = require(this.options.prismaPath || "@prisma/client").PrismaClient as PrismaClient;
+    const { PrismaClient } = require(this.options.prismaPath || "@prisma/client") as typeof import("@prisma/client");
 
-    const originalClient = new Client({
+    const originalClient = new PrismaClient({
       log: [{ level: "query", emit: "event" }],
       ...(this.options.databaseUrl && {
         datasources: {

--- a/packages/jest-prisma-core/src/types.ts
+++ b/packages/jest-prisma-core/src/types.ts
@@ -53,4 +53,12 @@ export interface JestPrismaEnvironmentOptions {
    *
    */
   readonly databaseUrl?: string;
+
+  /**
+   *
+   * Prisma client path. Useful for monorepos or when using a custom path for the generated prisma client.
+   *
+   * @default @prisma/client
+   */
+  readonly prismaPath?: string;
 }


### PR DESCRIPTION
Closes #29

Hey @Quramy, thanks for this amazing project!

This PR adds `prismaPath` option which allows the `PrismaClient` class to be imported from a custom location. All typings and source files were kept intact because the code does not interacts with the end user and typings are erased upon build. Only where the `new PrismaClient` call was executed needed to be changed.