### PR TITLE
feat: update verboseQuery option logging to include parameters

### DIFF
--- a/packages/jest-prisma-core/src/delegate.ts
+++ b/packages/jest-prisma-core/src/delegate.ts
@@ -135,7 +135,7 @@ export class PrismaEnvironmentDelegate implements PartialEnvironment {
       const breadcrumb = [this.testPath, ...nameFragments.reverse().slice(1)].join(" > ");
       console.log(chalk.blue.bold.inverse(" QUERY ") + " " + chalk.gray(breadcrumb));
       for (const event of this.logBuffer) {
-        console.log(`${chalk.blue("  jest-prisma:query")} ${event.query}`);
+        console.log(`${chalk.blue("  jest-prisma:query")} ${event.query} -- params:${event.params}`);
       }
     }
   }


### PR DESCRIPTION
closes: https://github.com/Quramy/jest-prisma/issues/94 

The log output with verboseQuery option is as follows:
```
// with params
SELECT `main`.`User`.`id`, `main`.`User`.`name` FROM `main`.`User` WHERE `main`.`User`.`id` = ? LIMIT ? OFFSET ? -- params ["user-1",1,0]

// no params
ROLLBACK -- params:[]
```