### PR TITLE
Expose the original `@prisma/client` module from `jestPrisma`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,18 @@ $ npm i @quramy/jest-prisma -D
 #### Configure Jest
 
 ```js
+/* setup-prisma.js */
+// Should mock `@prisma/client` module in Test Env by original module
+jest.mock("@prisma/client", () => jestPrisma.originalModule);
+```
+
+```js
 /* jest.config.mjs */
 export default {
   // ... Your jest configuration
 
   testEnvironment: "@quramy/jest-prisma/environment",
+  setupFilesAfterEnv: ["<rootDir>/setup-prisma.js"],
 };
 ```
 
@@ -131,20 +138,11 @@ You can replace the singleton instance to `jestPrisma.client` via `jest.mock`.
 
 ```js
 /* setup-prisma.js */
-
 jest.mock("./src/client", () => {
   return {
     prisma: jestPrisma.client,
   };
 });
-```
-
-```js
-/* jest.config.mjs */
-export default {
-  testEnvironment: "@quramy/jest-prisma/environment",
-  setupFilesAfterEnv: ["<rootDir>/setup-prisma.js"],
-};
 ```
 
 ```ts

--- a/packages/jest-prisma-core/src/delegate.ts
+++ b/packages/jest-prisma-core/src/delegate.ts
@@ -69,6 +69,7 @@ export class PrismaEnvironmentDelegate implements PartialEnvironment {
         },
       }),
       originalClient: this.originalClient,
+      originalModule: await import("@prisma/client"),
     };
     return jestPrisma;
   }

--- a/packages/jest-prisma-core/src/types.ts
+++ b/packages/jest-prisma-core/src/types.ts
@@ -10,6 +10,8 @@ export interface JestPrisma {
   readonly client: PrismaClient;
 
   readonly originalClient: PrismaClient;
+
+  readonly originalModule: typeof import("@prisma/client");
 }
 
 export interface JestPrismaEnvironmentOptions {


### PR DESCRIPTION
An error occurred when using the [raw database access](https://www.prisma.io/docs/concepts/components/prisma-client/raw-database-access) method and building raw query with `Prisma.sql` tag function. Example below:
```javascript
import { Prisma } from '@prisma/client'
const { client } = jestPrisma

const name = 'test'
const result = await client.$queryRaw`
  SELECT * FROM users
  ${Prisma.sql`WHERE name = ${name}`}
`
```
Error: ` Raw query failed. Code: 1064. Message: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '? ....'`

Cause: `jest` create worker that is a child process or a worker_thread (https://jestjs.io/docs/29.5/configuration#workerthreads). Worker will create a VM to execute the test file. The problem here is the `@prisma/client` module object in the worker is different with one in the VM