### PR TITLE
Allow customized Prisma client instance

### DIFF
--- a/examples/example-prj-customized-client/.gitignore
+++ b/examples/example-prj-customized-client/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+# Keep environment variables out of version control
+.env
+prisma/*.db
+prisma/*.db-journal

--- a/examples/example-prj-customized-client/jest.config.mjs
+++ b/examples/example-prj-customized-client/jest.config.mjs
@@ -1,0 +1,8 @@
+export default {
+  preset: "ts-jest",
+  transform: {
+    "^.+\\.tsx?$": ["ts-jest", { diagnostics: false }],
+  },
+  setupFilesAfterEnv: ["<rootDir>/setupAfterEnv.ts"],
+  testEnvironment: "@quramy/jest-prisma/environment",
+};

--- a/examples/example-prj-customized-client/package.json
+++ b/examples/example-prj-customized-client/package.json
@@ -1,0 +1,23 @@
+{
+  "private": true,
+  "name": "example-prj-customized-client",
+  "version": "1.6.0",
+  "scripts": {
+    "bootstrap": "npm run generate",
+    "migrate:test:ci": "DATABASE_URL=\"file:./test.db\" prisma migrate dev",
+    "generate": "prisma generate",
+    "test": "DATABASE_URL=\"file:./test.db\" jest",
+    "test:ci": "DATABASE_URL=\"file:./test.db\" jest"
+  },
+  "devDependencies": {
+    "@quramy/jest-prisma": "*",
+    "@prisma/client": "*",
+    "@types/jest": "29.2.1",
+    "prisma": "*",
+    "jest": "29.2.2",
+    "ts-jest": "29.0.3"
+  },
+  "dependencies": {
+    "sqlite": "4.1.2"
+  }
+}

--- a/examples/example-prj-customized-client/setupAfterEnv.ts
+++ b/examples/example-prj-customized-client/setupAfterEnv.ts
@@ -1,0 +1,3 @@
+import { prisma } from "./src/client";
+
+jestPrisma.initializeClient(prisma);

--- a/examples/example-prj-customized-client/src/client.test.ts
+++ b/examples/example-prj-customized-client/src/client.test.ts
@@ -1,0 +1,8 @@
+describe("Prisma Client", () => {
+  const prisma = jestPrisma.client;
+
+  test("with client extension", async () => {
+    expect(prisma.$myMethod()).toBe("my method");
+    await expect(prisma.user.count()).resolves.toBe(0);
+  });
+});

--- a/examples/example-prj-customized-client/src/client.ts
+++ b/examples/example-prj-customized-client/src/client.ts
@@ -1,0 +1,11 @@
+import { PrismaClient as PrismaConstructor } from "@prisma/client";
+
+export const prisma = new PrismaConstructor({
+  log: [{ level: "query", emit: "event" }],
+}).$extends({
+  client: {
+    $myMethod: () => "my method",
+  },
+});
+
+export type PrismaClient = typeof prisma;

--- a/examples/example-prj-customized-client/src/service/UserService.test.ts
+++ b/examples/example-prj-customized-client/src/service/UserService.test.ts
@@ -1,0 +1,22 @@
+import { UserService } from "./UserService";
+
+describe(UserService, () => {
+  const prisma = jestPrisma.client;
+
+  test("Add user", async () => {
+    const service = new UserService(prisma);
+    const createdUser = await service.addUser("quramy");
+
+    expect(
+      await prisma.user.findFirst({
+        where: {
+          name: "quramy",
+        },
+      }),
+    ).toStrictEqual(createdUser);
+  });
+
+  test("No users", async () => {
+    expect(await prisma.user.count()).toBe(0);
+  });
+});

--- a/examples/example-prj-customized-client/src/service/UserService.ts
+++ b/examples/example-prj-customized-client/src/service/UserService.ts
@@ -1,0 +1,17 @@
+import type { PrismaClient } from "@prisma/client";
+
+let seq = 1;
+
+export class UserService {
+  constructor(readonly prisma: PrismaClient) {}
+
+  async addUser(userName: string) {
+    const createdUser = await this.prisma.user.create({
+      data: {
+        id: `user-${seq++}`,
+        name: userName,
+      },
+    });
+    return createdUser;
+  }
+}

--- a/examples/example-prj-customized-client/tsconfig.json
+++ b/examples/example-prj-customized-client/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["@types/jest"]
+  },
+  "includes": ["typeDefs/**/*.ts"],
+  "references": [{ "path": "../../packages/jest-prisma" }]
+}

--- a/examples/example-prj-customized-client/typeDefs/jest-prisma.d.ts
+++ b/examples/example-prj-customized-client/typeDefs/jest-prisma.d.ts
@@ -1,0 +1,6 @@
+import type { JestPrisma } from "@quramy/jest-prisma-core";
+import type { prisma } from "../src/client";
+
+declare global {
+  var jestPrisma: JestPrisma<typeof prisma>;
+}

--- a/examples/example-prj-esm/package.json
+++ b/examples/example-prj-esm/package.json
@@ -7,7 +7,7 @@
     "bootstrap": "npm run generate",
     "migrate:test:ci": "DATABASE_URL=\"file:./test.db\" prisma migrate dev",
     "generate": "prisma generate",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "DATABASE_URL=\"file:./test.db\" NODE_OPTIONS=--experimental-vm-modules jest",
     "test:ci": "DATABASE_URL=\"file:./test.db\" NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "devDependencies": {

--- a/examples/example-prj/package.json
+++ b/examples/example-prj/package.json
@@ -6,7 +6,7 @@
     "bootstrap": "npm run generate",
     "migrate:test:ci": "DATABASE_URL=\"file:./test.db\" prisma migrate dev",
     "generate": "prisma generate",
-    "test": "jest",
+    "test": "DATABASE_URL=\"file:./test.db\" jest",
     "test:ci": "DATABASE_URL=\"file:./test.db\" jest"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,20 @@
         "ts-jest": "29.0.3"
       }
     },
+    "examples/example-prj-customized-client": {
+      "version": "1.6.0",
+      "dependencies": {
+        "sqlite": "4.1.2"
+      },
+      "devDependencies": {
+        "@prisma/client": "*",
+        "@quramy/jest-prisma": "*",
+        "@types/jest": "29.2.1",
+        "jest": "29.2.2",
+        "prisma": "*",
+        "ts-jest": "29.0.3"
+      }
+    },
     "examples/example-prj-esm": {
       "version": "1.6.0",
       "dependencies": {
@@ -1743,6 +1757,10 @@
     },
     "node_modules/example-prj": {
       "resolved": "examples/example-prj",
+      "link": true
+    },
+    "node_modules/example-prj-customized-client": {
+      "resolved": "examples/example-prj-customized-client",
       "link": true
     },
     "node_modules/example-prj-esm": {

--- a/packages/jest-prisma-core/src/loadDefaultClient.ts
+++ b/packages/jest-prisma-core/src/loadDefaultClient.ts
@@ -1,0 +1,16 @@
+import type { JestPrismaEnvironmentOptions } from "./types";
+
+export function loadDefaultClient(options: JestPrismaEnvironmentOptions) {
+  const { PrismaClient } = require("@prisma/client");
+  const client: unknown = new PrismaClient({
+    log: [{ level: "query", emit: "event" }],
+    ...(options.databaseUrl && {
+      datasources: {
+        db: {
+          url: options.databaseUrl,
+        },
+      },
+    }),
+  });
+  return client;
+}

--- a/packages/jest-prisma-core/src/types.ts
+++ b/packages/jest-prisma-core/src/types.ts
@@ -19,6 +19,13 @@ export interface JestPrisma<T = PrismaClientLike> {
   readonly client: T;
 
   readonly originalClient: T;
+
+  /**
+   *
+   * You can call this from setupAfterEnv script and set your customized PrismaClient instance.
+   *
+   */
+  readonly initializeClient: (client: unknown) => void;
 }
 
 export interface JestPrismaEnvironmentOptions {

--- a/packages/jest-prisma-core/src/types.ts
+++ b/packages/jest-prisma-core/src/types.ts
@@ -1,15 +1,24 @@
-import type { PrismaClient } from "@prisma/client";
+export interface PrismaClientLike {
+  $connect: () => Promise<unknown>;
+  $disconnect: () => Promise<unknown>;
+  $transaction: (
+    fn: (txClient: PrismaClientLike) => Promise<unknown>,
+    Options?: { maxWait: number; timeout: number },
+  ) => Promise<unknown>;
+  $executeRawUnsafe: (query: string) => Promise<number>;
+  $on: (event: "query", callbacck: (event: { readonly query: string; readonly params: string }) => unknown) => void;
+}
 
-export interface JestPrisma {
+export interface JestPrisma<T = PrismaClientLike> {
   /**
    *
    * Primsa Client Instance whose transaction are isolated for each test case.
    * And this transaction is rolled back automatically after each test case.
    *
    */
-  readonly client: PrismaClient;
+  readonly client: T;
 
-  readonly originalClient: PrismaClient;
+  readonly originalClient: T;
 }
 
 export interface JestPrismaEnvironmentOptions {

--- a/packages/jest-prisma-node/src/environment.ts
+++ b/packages/jest-prisma-node/src/environment.ts
@@ -16,7 +16,7 @@ export default class PrismaEnvironment extends Environment {
   async setup() {
     const jestPrisma = await this.delegate.preSetup();
     await super.setup();
-    this.global.jestPrisma = jestPrisma;
+    this.global.jestPrisma = jestPrisma as any;
   }
 
   handleTestEvent(event: Circus.Event) {

--- a/packages/jest-prisma-node/src/index.ts
+++ b/packages/jest-prisma-node/src/index.ts
@@ -1,8 +1,9 @@
+import type { PrismaClient } from "@prisma/client";
 import type { JestPrisma } from "@quramy/jest-prisma-core";
 import Env from "./environment";
 
 export const PrismaEnvironment = Env;
 
 declare global {
-  var jestPrisma: JestPrisma;
+  var jestPrisma: JestPrisma<PrismaClient>;
 }

--- a/packages/jest-prisma/src/environment.ts
+++ b/packages/jest-prisma/src/environment.ts
@@ -16,7 +16,7 @@ export default class PrismaEnvironment extends Environment {
   async setup() {
     const jestPrisma = await this.delegate.preSetup();
     await super.setup();
-    this.global.jestPrisma = jestPrisma;
+    this.global.jestPrisma = jestPrisma as any;
   }
 
   handleTestEvent(event: Circus.Event) {

--- a/packages/jest-prisma/src/index.ts
+++ b/packages/jest-prisma/src/index.ts
@@ -1,8 +1,9 @@
+import type { PrismaClient } from "@prisma/client";
 import type { JestPrisma } from "@quramy/jest-prisma-core";
 import Env from "./environment";
 
 export const PrismaEnvironment = Env;
 
 declare global {
-  var jestPrisma: JestPrisma;
+  var jestPrisma: JestPrisma<PrismaClient>;
 }


### PR DESCRIPTION
It fixes #29, #47 .

I introduce `jestPrisma.initializeClient` function. 

Usecases:

1.  Prisma client JavaScript are generated to non-default location (#29)
2. User extends / customize Prisma client instance (#47)