### PR TITLE
fix: don't show premature access warning on ES Module import

### DIFF
--- a/packages/jest-prisma-core/src/delegate.ts
+++ b/packages/jest-prisma-core/src/delegate.ts
@@ -47,12 +47,14 @@ export class PrismaEnvironmentDelegate implements PartialEnvironment {
       client: new Proxy<PrismaClientLike>({} as never, {
         get: (_, name: keyof PrismaClientLike) => {
           if (!this.prismaClientProxy) {
-            console.warn(
-              "jsetPrisma.client should be used in test or beforeEach functions because transaction has not yet started.",
-            );
-            console.warn(
-              "If you want to access Prisma client in beforeAll or afterAll, use jestPrisma.originalClient.",
-            );
+            if ((name as string) !== "__esModule") {
+              console.warn(
+                "jestPrisma.client should be used in test or beforeEach functions because transaction has not yet started.",
+              );
+              console.warn(
+                "If you want to access Prisma client in beforeAll or afterAll, use jestPrisma.originalClient.",
+              );
+            }
           } else {
             return this.prismaClientProxy[name];
           }


### PR DESCRIPTION
We had a bunch of the following warnings when tests were starting up:

```
If you want to access Prisma client in beforeAll or afterAll, use jestPrisma.originalClient.
jsetPrisma.client should be used in test or beforeEach functions because transaction has not yet started.
```

The culprit was the ES Module system that asks for a property called `__esModule` on the proxied instance every time we import the module.

The changes in this PR are the following:

* Only show the warning if the property name is not `__esModule`. 
* Fix the spelling in the warning from `jsetPrisma` to `jestPrisma`.

