### PR TITLE
add test_todo event handling for endTransaction

### DIFF
--- a/packages/jest-prisma-core/src/delegate.ts
+++ b/packages/jest-prisma-core/src/delegate.ts
@@ -70,7 +70,7 @@ export class PrismaEnvironmentDelegate implements PartialEnvironment {
   handleTestEvent(event: Circus.Event) {
     if (event.name === "test_start") {
       return this.beginTransaction();
-    } else if (event.name === "test_done" || event.name === "test_skip") {
+    } else if (event.name === "test_done" || event.name === "test_skip" || event.name === "test_todo") {
       return this.endTransaction();
     } else if (event.name === "test_fn_start") {
       this.logBuffer = [];


### PR DESCRIPTION
For a `test.todo`, jest still fires the test_start event (which triggers a new transaction) but instead of the test_done event, it fires test_todo. We need to call endTransaction for both events in order to properly close all transactions.