### PR TITLE
[Closes Issue #129] Adds option to configure isolation level

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,15 @@ export interface JestPrismaEnvironmentOptions {
 
   /**
    *
+   * Sets the transaction isolation level. By default this is set to the value currently configured in your database.
+   *
+   * @link https://www.prisma.io/docs/orm/prisma-client/queries/transactions#transaction-isolation-level
+   *
+   */
+  readonly isolationLevel?: Prisma.TransactionIsolationLevel;
+
+  /**
+   *
    * Override the database connection URL.
    *
    * Useful if you have a separate database for testing.

--- a/packages/jest-prisma-core/src/delegate.ts
+++ b/packages/jest-prisma-core/src/delegate.ts
@@ -12,6 +12,7 @@ type PartialEnvironment = Pick<JestEnvironment<unknown>, "handleTestEvent" | "te
 
 const DEFAULT_MAX_WAIT = 5_000;
 const DEFAULT_TIMEOUT = 5_000;
+const DEFAULT_ISOLATION_LEVEL = undefined; // use database default
 
 export class PrismaEnvironmentDelegate implements PartialEnvironment {
   private _originalClient: PrismaClientLike | undefined;
@@ -127,6 +128,7 @@ export class PrismaEnvironmentDelegate implements PartialEnvironment {
           {
             maxWait: this.options.maxWait ?? DEFAULT_MAX_WAIT,
             timeout: this.options.timeout ?? DEFAULT_TIMEOUT,
+            isolationLevel: this.options.isolationLevel ?? DEFAULT_ISOLATION_LEVEL,
           },
         )
         .catch(() => true),

--- a/packages/jest-prisma-core/src/types.ts
+++ b/packages/jest-prisma-core/src/types.ts
@@ -1,9 +1,16 @@
+type PrismaTransactionIsolationLevel =
+  | "ReadUncommitted"
+  | "ReadCommitted"
+  | "RepeatableRead"
+  | "Snapshot"
+  | "Serializable";
+
 export interface PrismaClientLike {
   $connect: () => Promise<unknown>;
   $disconnect: () => Promise<unknown>;
   $transaction: (
     fn: (txClient: PrismaClientLike) => Promise<unknown>,
-    Options?: { maxWait: number; timeout: number },
+    Options?: { maxWait: number; timeout: number; isolationLevel?: PrismaTransactionIsolationLevel },
   ) => Promise<unknown>;
   $executeRawUnsafe: (query: string) => Promise<number>;
   $on: (event: "query", callbacck: (event: { readonly query: string; readonly params: string }) => unknown) => void;
@@ -69,6 +76,15 @@ export interface JestPrismaEnvironmentOptions {
    *
    */
   readonly timeout?: number;
+
+  /**
+   *
+   * Sets the transaction isolation level. By default this is set to the value currently configured in your database.
+   *
+   * @link https://www.prisma.io/docs/orm/prisma-client/queries/transactions#supported-isolation-levels
+   *
+   */
+  readonly isolationLevel?: PrismaTransactionIsolationLevel;
 
   /**
    *


### PR DESCRIPTION
[Closes Issue #129] Adds option to configure isolation level

This option sets the transaction isolation level. By default, this is set to the value currently configured in your database.

I included a link to the prisma docs that help explain the options


## Note

I was unsure how to run any tests locally as there might be setup steps like running `prisma generate`

I was able to run `npm run build:lib` without any build errors

