### PR TITLE
Adds back await to teardown

### DIFF
--- a/packages/jest-prisma-core/src/delegate.ts
+++ b/packages/jest-prisma-core/src/delegate.ts
@@ -82,7 +82,7 @@ export class PrismaEnvironmentDelegate implements PartialEnvironment {
   }
 
   async teardown() {
-    this.originalClient.$disconnect?.();
+    await this.originalClient.$disconnect?.();
   }
 
   private get originalClient() {


### PR DESCRIPTION
disconnect needs to be await'd per examples here: https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/databases-connections/connection-management#calling-disconnect-explicitly

As far as I can tell in github's git blame this was removed with this commit: https://github.com/Quramy/jest-prisma/commit/5e19e90b1b6161fb8e9b348bc6092cdb5c316b65

Unsure how to run any tests in development so likely good to spot check before merging and cutting a new version

Thanks again for all the work here!

Think might be related to https://github.com/Quramy/jest-prisma/issues/98