### PR TITLE
feat: allow clientPath configuration for delegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,15 @@ export interface JestPrismaEnvironmentOptions {
    *
    */
   readonly databaseUrl?: string;
+
+  /**
+   *
+   * Override the path to the Prisma Client.
+   *
+   * If this is not set, defaults to `@prisma/client`.
+   *
+   */
+  readonly clientPath?: string;
 }
 ```
 

--- a/packages/jest-prisma-core/src/loadDefaultClient.ts
+++ b/packages/jest-prisma-core/src/loadDefaultClient.ts
@@ -1,7 +1,7 @@
 import type { JestPrismaEnvironmentOptions } from "./types";
 
 export function loadDefaultClient(options: JestPrismaEnvironmentOptions) {
-  const { PrismaClient } = require("@prisma/client");
+  const { PrismaClient } = require(options.clientPath ?? "@prisma/client");
   const client: unknown = new PrismaClient({
     log: [{ level: "query", emit: "event" }],
     ...(options.databaseUrl && {

--- a/packages/jest-prisma-core/src/types.ts
+++ b/packages/jest-prisma-core/src/types.ts
@@ -94,4 +94,13 @@ export interface JestPrismaEnvironmentOptions {
    *
    */
   readonly databaseUrl?: string;
+
+  /**
+   *
+   * Override the path to the Prisma Client.
+   *
+   * If this is not set, defaults to `@prisma/client`.
+   *
+   */
+  readonly clientPath?: string;
 }


### PR DESCRIPTION
This allows passing a `clientPath` option to environments, allowing to import the prisma client from a custom directory, but defaulting to `@prisma/client`.

Fixes #173 