### PR TITLE
Fix compatibility with Prisma 7.5.0 nested transactions

### DIFF
--- a/packages/jest-prisma-core/src/delegate.ts
+++ b/packages/jest-prisma-core/src/delegate.ts
@@ -186,6 +186,13 @@ function fakeInnerTransactionFactory(
         throw err;
       }
     } else {
+      if (parentTxClient.$transaction) {
+        // Prisma 7.5.0+ handles nested transactions natively with savepoints
+        // No need for manual savepoint management
+        return await parentTxClient.$transaction(arg)
+      }
+
+      // Fallback for Prisma < 7.5.0: use manual savepoint management
       try {
         const result = await arg(parentTxClient);
         if (enableExperimentalRollbackInTransaction) {
@@ -210,11 +217,11 @@ function createProxy(txClient: PrismaClientLike, originalClient: any, options: J
   );
   return new Proxy(txClient, {
     get: (target, name) => {
-      const delegate = target[name as keyof PrismaClientLike];
-      if (delegate) return delegate;
       if (name === "$transaction") {
         return boundFakeTransactionMethod;
       }
+      const delegate = target[name as keyof PrismaClientLike];
+      if (delegate) return delegate;
       if (originalClient[name as keyof PrismaClientLike]) {
         throw new Error(`Unsupported property: ${name.toString()}`);
       }


### PR DESCRIPTION
Fix for Prisma 7.5.0 nested transaction support

**Issue:**
  
[Prisma 7.5.0 added `$transaction` to transaction clients](https://github.com/prisma/prisma/pull/21678/changes#diff-d5d89718330edd99af299a8507100818cde620cfeedc8a222570439607d0de14L1
). 

Without this fix, the proxy would delegate to the native method before interception, causing sequential transactions to hang as Prisma's implementation doesn't support savepoints for array-based transactions.

**Changes:**

- Changed proxy delegation order to prioritize `$transaction` interception
- For interactive transactions (callback): Delegates to Prisma's native implementation if available
(7.5.0+), otherwise falls back to savepoint-based fake method
- For sequential transactions (array): Continues to use savepoint-based fake method (unchanged)

  